### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://c9-odata.visualstudio.com/64ef8122-a6a3-4c74-a51e-2a5c96dbc758/4f83b1a9-e5e4-4bd5-ba9b-27c0fb273a2e/_apis/work/boardbadge/9d2e477c-839c-427a-bfb2-abcd8c058b00)](https://c9-odata.visualstudio.com/64ef8122-a6a3-4c74-a51e-2a5c96dbc758/_boards/board/t/4f83b1a9-e5e4-4bd5-ba9b-27c0fb273a2e/Microsoft.RequirementCategory)
 # testing-azure-boards
 testing azure boards integration with github


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://c9-odata.visualstudio.com/64ef8122-a6a3-4c74-a51e-2a5c96dbc758/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.